### PR TITLE
Add ability to set request format to headerize the flash for APIs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,33 @@ responses).
 
 If you want to skip the glow after_filter just set `flash[:skip_glow]`.
 
+
+You can also use glow with APIs by using `headerize_flash_for` and passing
+in the request formats you want the flash messages passed back.
+
+``` ruby
+class API::Base < ActionController::Base
+  headerize_flash_for :json
+end
+```
+
+Controllers inheriting from a controller using `headerize_format_for` will
+inherit the capability or it can be overridden.
+
+``` ruby
+class API::JSON < API::Base
+  # will headerize flash for JSON requests
+end
+
+class API::XML < API::Base
+  headerize_flash_for :xml
+  # will NOT headerize flash for JSON requests
+  # but will headerize flash for XML requests
+end
+```
+
+
+
 ## Installation
 
 In your gemfile add

--- a/lib/glow/filter.rb
+++ b/lib/glow/filter.rb
@@ -4,17 +4,30 @@ module Glow
   module Filter
     extend ActiveSupport::Concern
     included do
-      after_filter :flash_to_headers
+      after_filter    :flash_to_headers
+      class_attribute :glow_request_formats
     end
 
     def flash_to_headers
-      return unless flash.any? && request.xhr?
+      return unless flash.any? && flash_to_headers?
       return if flash[:skip_glow] and flash.delete(:skip_glow)
 
       type, message = flash.first
       response.headers['X-Message'] = message.to_s.unpack('U*').map{ |i| "&##{i};" }.join
         response.headers['X-Message-Type'] = type.to_s
       flash.discard  # don't want the flash to appear when you reload page
+    end
+
+    def flash_to_headers?
+      request.xhr? ||
+      glow_request_formats? && glow_request_formats.include?(request.format.to_sym)
+    end
+
+
+    module ClassMethods
+      def headerize_flash_for *formats
+        self.glow_request_formats = formats
+      end
     end
 
   end

--- a/test/rails3/app/controllers/flash_controller.rb
+++ b/test/rails3/app/controllers/flash_controller.rb
@@ -1,20 +1,25 @@
 class FlashController < ApplicationController
+
+  headerize_flash_for :json
+
   def show
     # show.html.erb
   end
 
   def redirect
-    flash[params[:type]] = params[:message]
+    flash[params[:type].to_sym] = params[:message]
     redirect_to action: 'show'
   end
 
   def ajax
     respond_to do |wants|
-      wants.js {
-        flash[params[:type]] = params[:message]
-        flash[:skip_glow] = params[:skip_glow].present?
-        head :ok
-      }
+      [:js, :json, :xml].each do |fmt|
+        wants.send(fmt) {
+          flash[params[:type].to_sym] = params[:message]
+          flash[:skip_glow] = params[:skip_glow].present?
+          head :ok
+        }
+      end
     end
   end
 end

--- a/test/rails3/spec/controllers/flash_controller_spec.rb
+++ b/test/rails3/spec/controllers/flash_controller_spec.rb
@@ -15,7 +15,7 @@ describe FlashController do
     flash.keep?(:notice).should be true
   end
 
-  it "should display flash message on xhr" do 
+  it "should display flash message on xhr" do
     xhr :get, :ajax, type: :notice, message: 'Glow!'
 
     flash[:notice].should be == 'Glow!'
@@ -34,5 +34,22 @@ describe FlashController do
   it "should not display flash message on xhr when skip_glow is set" do
     xhr :get, :ajax, type: :notice, message: 'utf8: ✓', skip_glow: true
     @response.headers.should_not have_key 'X-Message-Type'
+  end
+
+  it "should pass flash message on JSON requests" do
+    get :ajax, type: :notice, message: 'Glow!', format: :json
+
+    flash[:notice].should be == 'Glow!'
+    flash.discard?(:notice).should be true
+
+    @response.headers['X-Message-Type'].should be == 'notice'
+    HTMLEntities.new.decode(@response.headers['X-Message']).should be == 'Glow!'
+  end
+
+  it "should not pass flash message on XML requests" do
+    get :ajax, type: :notice, message: 'Glow!', format: :xml
+
+    @response.headers['X-Message-Type'].should be_nil
+    @response.headers['X-Message'].should be_nil
   end
 end

--- a/test/rails31/app/controllers/flash_controller.rb
+++ b/test/rails31/app/controllers/flash_controller.rb
@@ -1,4 +1,7 @@
 class FlashController < ApplicationController
+
+  headerize_flash_for :json
+
   def show
     # show.html.erb
   end
@@ -10,11 +13,13 @@ class FlashController < ApplicationController
 
   def ajax
     respond_to do |wants|
-      wants.js {
-        flash[params[:type].to_sym] = params[:message]
-        flash[:skip_glow] = params[:skip_glow].present?
-        head :ok
-      }
+      [:js, :json, :xml].each do |fmt|
+        wants.send(fmt) {
+          flash[params[:type].to_sym] = params[:message]
+          flash[:skip_glow] = params[:skip_glow].present?
+          head :ok
+        }
+      end
     end
   end
 end

--- a/test/rails31/spec/controllers/flash_controller_spec.rb
+++ b/test/rails31/spec/controllers/flash_controller_spec.rb
@@ -15,7 +15,7 @@ describe FlashController do
     flash.keep?(:notice).should be true
   end
 
-  it "should display flash message on xhr" do 
+  it "should display flash message on xhr" do
     xhr :get, :ajax, type: :notice, message: 'Glow!'
 
     flash[:notice].should be == 'Glow!'
@@ -34,5 +34,22 @@ describe FlashController do
   it "should not display flash message on xhr when skip_glow is set" do
     xhr :get, :ajax, type: :notice, message: 'utf8: ✓', skip_glow: true
     @response.headers.should_not have_key 'X-Message-Type'
+  end
+
+  it "should pass flash message on JSON requests" do
+    get :ajax, type: :notice, message: 'Glow!', format: :json
+
+    flash[:notice].should be == 'Glow!'
+    flash.discard?(:notice).should be true
+
+    @response.headers['X-Message-Type'].should be == 'notice'
+    HTMLEntities.new.decode(@response.headers['X-Message']).should be == 'Glow!'
+  end
+
+  it "should not pass flash message on XML requests" do
+    get :ajax, type: :notice, message: 'Glow!', format: :xml
+
+    @response.headers['X-Message-Type'].should be_nil
+    @response.headers['X-Message'].should be_nil
   end
 end

--- a/test/rails32/app/controllers/flash_controller.rb
+++ b/test/rails32/app/controllers/flash_controller.rb
@@ -1,4 +1,7 @@
 class FlashController < ApplicationController
+
+  headerize_flash_for :json
+
   def show
     # show.html.erb
   end
@@ -10,11 +13,13 @@ class FlashController < ApplicationController
 
   def ajax
     respond_to do |wants|
-      wants.js {
-        flash[params[:type].to_sym] = params[:message]
-        flash[:skip_glow] = params[:skip_glow].present?
-        head :ok
-      }
+      [:js, :json, :xml].each do |fmt|
+        wants.send(fmt) {
+          flash[params[:type].to_sym] = params[:message]
+          flash[:skip_glow] = params[:skip_glow].present?
+          head :ok
+        }
+      end
     end
   end
 end

--- a/test/rails32/spec/controllers/flash_controller_spec.rb
+++ b/test/rails32/spec/controllers/flash_controller_spec.rb
@@ -15,7 +15,7 @@ describe FlashController do
     flash.keep?(:notice).should be true
   end
 
-  it "should display flash message on xhr" do 
+  it "should display flash message on xhr" do
     xhr :get, :ajax, type: :notice, message: 'Glow!'
 
     flash[:notice].should be == 'Glow!'
@@ -34,5 +34,22 @@ describe FlashController do
   it "should not display flash message on xhr when skip_glow is set" do
     xhr :get, :ajax, type: :notice, message: 'utf8: ✓', skip_glow: true
     @response.headers.should_not have_key 'X-Message-Type'
+  end
+
+  it "should pass flash message on JSON requests" do
+    get :ajax, type: :notice, message: 'Glow!', format: :json
+
+    flash[:notice].should be == 'Glow!'
+    flash.discard?(:notice).should be true
+
+    @response.headers['X-Message-Type'].should be == 'notice'
+    HTMLEntities.new.decode(@response.headers['X-Message']).should be == 'Glow!'
+  end
+
+  it "should not pass flash message on XML requests" do
+    get :ajax, type: :notice, message: 'Glow!', format: :xml
+
+    @response.headers['X-Message-Type'].should be_nil
+    @response.headers['X-Message'].should be_nil
   end
 end


### PR DESCRIPTION
You can now use glow with APIs by using `headerize_flash_for` and passing
in the request formats you want the flash messages passed back.

``` ruby
class API::Base < ActionController::Base
  headerize_flash_for :json
end
```

Controllers inheriting from a controller using `headerize_format_for` will
inherit the capability or it can be overridden.

``` ruby
class API::JSON < API::Base
  # will headerize flash for JSON requests
end

class API::XML < API::Base
  headerize_flash_for :xml
  # will NOT headerize flash for JSON requests
  # but will headerize flash for XML requests
end
```
