### PR TITLE
don't depend on rails

### DIFF
--- a/glow.gemspec
+++ b/glow.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--main', 'README.md', '--charset=UTF-8']
   s.extra_rdoc_files = ['README.md', 'MIT-LICENSE']
 
-  s.add_dependency "rails", ">= 3.0.0"
+  s.add_dependency "railties", ">= 3.0.0"
+  s.add_dependency "actionpack", ">= 3.0.0"
   s.add_dependency "jquery-rails"
 end


### PR DESCRIPTION
this allows it to use glow without the need of rails and all of it's dependencies, for example if you don't want to use actioncable.